### PR TITLE
Implement global debugging support

### DIFF
--- a/cmd/syringe/main.go
+++ b/cmd/syringe/main.go
@@ -28,6 +28,14 @@ func main() {
 					"SYRINGE_DEBUG",
 				},
 			},
+			&cli.BoolFlag{
+				Name:  "debug-global",
+				Usage: "Whether to enable debug logging for all Syringe clients. Useful only when dbus is enabled",
+				Value: false,
+				EnvVars: []string{
+					"SYRINGE_DEBUG_GLOBAL",
+				},
+			},
 		},
 		Commands: []*cli.Command{
 			{
@@ -68,7 +76,7 @@ func main() {
 			},
 		},
 		Before: func(cctx *cli.Context) (err error) {
-			if err = setupLogging(cctx.Bool("debug")); err != nil {
+			if err = setupLogging(cctx.Bool("debug") || cctx.Bool("debug-global")); err != nil {
 				return
 			}
 

--- a/cmd/syringe/server.go
+++ b/cmd/syringe/server.go
@@ -88,6 +88,7 @@ func serverEntrypoint(clictx *cli.Context) (err error) {
 		cctx.WithVaultClient(vault),
 		cctx.WithTemplateMap(tm),
 		cctx.WithSocketPaths(socketPaths),
+		cctx.WithGlobalDebug(clictx.Bool("debug-global")),
 	)
 
 	if clictx.Bool("dbus") {

--- a/internal/ctx/ctx.go
+++ b/internal/ctx/ctx.go
@@ -70,3 +70,14 @@ func SocketPaths(ctx context.Context) (v []string) {
 	v = ctx.Value(socketPath).([]string)
 	return
 }
+
+func WithGlobalDebug(gd bool) ContextValueFunc {
+	return func(ctx context.Context) context.Context {
+		return context.WithValue(ctx, globalDebug, gd)
+	}
+}
+
+func GlobalDebug(ctx context.Context) (v bool) {
+	v = ctx.Value(globalDebug).(bool)
+	return
+}

--- a/internal/ctx/values.go
+++ b/internal/ctx/values.go
@@ -8,4 +8,5 @@ var (
 	credentialReqUnit contextValue = "ctx:cru"
 	credentialReqCred contextValue = "ctx:crc"
 	socketPath        contextValue = "ctx:sp"
+	globalDebug       contextValue = "ctx:gd"
 )

--- a/internal/dbus/syringe_svc.go
+++ b/internal/dbus/syringe_svc.go
@@ -23,6 +23,11 @@ const intro = introspect.IntrospectDeclarationString + `
                 <doc:doc><doc:summary>Path to the Unix sockets where Syringe is currently listening on</doc:summary></doc:doc>
             </arg>
         </method>
+        <method name="GetGlobalDebug">
+            <arg direction="out" type="ab">
+                <doc:doc><doc:summary>Whether global debugging is enabled</doc:summary></doc:doc>
+            </arg>
+        </method>
     </interface>
     ` + introspect.IntrospectDataString + `
 </node>
@@ -36,6 +41,11 @@ type syringeService struct {
 
 func (s *syringeService) GetSocketPaths() (v []string, err *dbus.Error) {
 	v = cctx.SocketPaths(s.ctx)
+	return
+}
+
+func (s *syringeService) GetGlobalDebug() (v bool, err *dbus.Error) {
+	v = cctx.GlobalDebug(s.ctx)
 	return
 }
 


### PR DESCRIPTION
- [x] Implement `--debug-global` flag for server
- [x] Expose global debug flag over D-Bus API
- [ ] Make client (`syringe update`) query & honor it.